### PR TITLE
Fix YAML frontmatter format in mimeng-writing skill

### DIFF
--- a/mimeng-writing/SKILL.md
+++ b/mimeng-writing/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   author: Qianru Tian
   email: fleurytian@gmail.com
   social: 小红书@如宝｜AI&Analytics
-  GitHub:fleurytian
+  GitHub: fleurytian
 ---
 
 # 咪蒙写作技巧 - 10万+爆款文章创作指南


### PR DESCRIPTION
## Summary
Fix malformed YAML frontmatter in mimeng-writing SKILL.md file.

## Changes
- Add missing space after colon in GitHub metadata field (`GitHub:fleurytian` → `GitHub: fleurytian`)

## Impact
This fix resolves the "malformed YAML frontmatter in SKILL.md" error when uploading the skill to Claude client.

## Test plan
- [x] Fixed YAML syntax error
- [x] Recreated zip package
- [x] Verified skill can be imported without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)