### PR TITLE
Add find-session skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,45 @@ awesome-claude-skills/
 
 ---
 
-### 3️⃣ US Government Shutdown Tracker Skill
+### 3️⃣ find-session Skill
+**精确锁定并一键 resume 某个特定的 Claude Code 对话**
+
+`claude --continue` 只能"按目录最近一次"挑会话,在长时间多对话并行时经常选错。这个 skill 帮你用 grep 验证某段对话的真正 UUID,然后写到 `~/.zshrc` 当 shell function — 以后任何新 terminal 打一个词就回到那个对话。
+
+#### 💡 解决的问题
+
+- 多个长期对话并行时,`claude --continue` 选错
+- 多个 Claude Code 进程可能"声称"同一 UUID,只能靠 grep 独特字符串验证
+- Session 是按"启动时 cwd"索引的,不是按"工作目录" — alias 要 `cd "$HOME"` 才能找到 home-dir bucket 里的会话
+
+#### 🚀 快速开始
+
+```
+"我找不到我的对话,帮我找出来"
+```
+
+或显式触发:
+
+```
+/find-session
+```
+
+Skill 会按步骤问你独特内容(文件名 / URL / 函数名),grep 所有 jsonl 找匹配,然后让你起个短名(如 `aichain` / `headsup`),自动写到 `~/.zshrc`。
+
+#### 📝 几条关键经验
+
+- **最大的 jsonl 不一定是你的** — 必须靠 grep 实际内容验证
+- **`cd "$HOME"`** 因为 session 按启动 cwd 索引,不是工作目录
+- **多个并发 session** 时,两个 Claude 实例可能都声称同一 UUID — 只能靠 grep 唯一内容辨认
+
+适合:
+- 工作 / 研究类长期会话(几天到几周一直在跟同一个 Claude 聊)
+- 跨项目混合会话(home 目录起的会话占多数)
+- 重装系统 / 换电脑后想找回之前的对话
+
+---
+
+### 4️⃣ US Government Shutdown Tracker Skill
 **美国政府停摆流动性分析器**
 
 实时追踪和分析美国政府停摆对金融市场流动性影响的专业工具,基于FRED数据提供自动化分析。

--- a/find-session/README.md
+++ b/find-session/README.md
@@ -1,0 +1,62 @@
+# find-session
+
+Pin a specific Claude Code conversation by UUID and resume it with a one-word shell command.
+
+## What it solves
+
+`claude --continue` picks the *most recent* conversation in the current directory — unreliable when:
+
+- You have multiple long-running parallel conversations in the same project
+- You started Claude Code from `~` (so all your sessions live in the home-dir bucket)
+- The "most recent" jumps around as you switch tasks
+
+`claude --resume <uuid>` is exact, but you have to find the right UUID, and there can be more than one Claude instance claiming the same one.
+
+This skill walks Claude through the right grep-the-jsonl workflow, then pins the verified UUID as a `~/.zshrc` shell function so you can type e.g. `headsup` from any new terminal and land in the exact same conversation.
+
+## When to use
+
+- "I can't find my conversation" / "claude --continue picks the wrong one"
+- "I want a one-word command to resume my long-running [project] session"
+- Multiple `.jsonl` files exist under `~/.claude/projects/<encoded-cwd>/`
+
+## How to invoke
+
+```
+我找不到我的对话, 帮我找出来
+```
+
+or explicitly:
+
+```
+/find-session
+```
+
+The skill will:
+
+1. List `~/.claude/projects/*/` and find the most recently active bucket
+2. List all `.jsonl` files in that bucket (each = one conversation)
+3. Ask you for a unique-content hint (a filename, URL, function name only this conversation would contain)
+4. `grep -c` that string across every `.jsonl` to identify the right one
+5. Confirm UUID, ask for a short alias name (e.g. `aichain`, `headsup`, `work`)
+6. Append a function to `~/.zshrc`:
+
+   ```bash
+   <name>() {
+     cd "$HOME" && claude --resume "<uuid>"
+   }
+   ```
+
+7. Tell you to `source ~/.zshrc` (or open a new terminal) — done.
+
+## Why grep-not-size
+
+The biggest `.jsonl` is **not** necessarily yours. Multiple Claude Code processes can attach to the same conversation file simultaneously and any of them might be confused about which UUID it lives under. Only matching against unique content you remember writing or generating is reliable.
+
+## Why `cd "$HOME"`
+
+Sessions are indexed by their **starting** cwd, not by where the work happened. A session started from `~` lives under `~/.claude/projects/-Users-yourname/`, even if the conversation cd'd into a project subdirectory. The alias must `cd "$HOME"` so `claude --resume <uuid>` looks in the right project bucket.
+
+## License
+
+MIT — see repo root.

--- a/find-session/SKILL.md
+++ b/find-session/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: find-session
+description: Identify a specific Claude Code conversation by its UUID and optionally pin it as a shell function for one-word resume. Use when "claude --continue" picks the wrong session, or when the user wants to reliably resume a specific past conversation across reboots.
+---
+
+# find-session — pin a specific Claude conversation
+
+`claude --continue` picks "most recent in cwd" — unreliable when multiple
+sessions share a directory. `claude --resume <uuid>` is exact. This skill
+finds the right UUID by grepping jsonl files, then writes a one-word shell
+function so the user types e.g. `aichain` to resume that exact conversation.
+
+## When to use
+
+- User says "I can't find my session" / "claude --continue picks wrong one"
+- User wants a one-word resume command for a specific long-running conversation
+- Multiple `.jsonl` files in `~/.claude/projects/<encoded-cwd>/` exist
+
+## Workflow
+
+### 1. Find the encoded-cwd directory
+
+Sessions are stored under `~/.claude/projects/<encoded-cwd>/`. The encoding
+replaces `/` with `-`, so cwd `/Users/foo/Desktop/MyProj` becomes
+`-Users-foo-Desktop-MyProj`. Often the cwd at session-start was the user's
+HOME, even if work happened in a subdirectory.
+
+If unsure which encoded-cwd to scan:
+
+```bash
+ls -dt ~/.claude/projects/*/ | head -5
+```
+
+The most recently modified directory is likely the right one.
+
+### 2. List active session files
+
+```bash
+ls -lt ~/.claude/projects/<encoded-cwd>/*.jsonl 2>/dev/null | head -10
+```
+
+Multiple files = multiple sessions. **The biggest by size is NOT
+necessarily the right one** — both the current assistant and other parallel
+sessions can be wrong about that.
+
+### 3. Get a unique-content hint from the user
+
+Ask: "What's something only this conversation would contain? A specific
+filename you created, a unique tool you ran, a project name, etc."
+
+Good hints (highly unique):
+- A hostname / URL the conversation generated (e.g. `waqvu5.png`)
+- A file path that was created by this session (e.g. `kimi_research_results`)
+- A specific function name written in this session (e.g. `compute_factor_scores`)
+- A unique error message they remember
+
+Bad hints (too common, will match multiple):
+- Generic words like "Python", "test", "fix"
+- Common library names
+
+### 4. grep to find matching session
+
+```bash
+for f in ~/.claude/projects/<encoded-cwd>/*.jsonl; do
+  echo "=== $(basename "$f") ==="
+  grep -c "<unique-string>" "$f" 2>/dev/null
+done
+```
+
+The session with non-zero hits (ideally many hits) is the answer. Confirm
+with 2-3 different unique strings if the first match is ambiguous.
+
+### 5. Offer to pin as shell function
+
+Once UUID is identified, ask user for a short name (e.g. `aichain`,
+`work`, `headsup`). Then append to `~/.zshrc`:
+
+```bash
+# <project description> — resume specific session
+<short-name>() {
+  cd "$HOME" && claude --resume "<uuid>"
+}
+```
+
+`cd "$HOME"` matters: sessions are indexed by their starting cwd, so the
+alias must cd to the same place where the session was originally created
+(often HOME, even if the actual work touched subdirectories).
+
+After write, tell user to either:
+- Run `source ~/.zshrc` in current terminal, OR
+- Open a new terminal
+
+## Important notes
+
+- Each `.jsonl` is the full transcript log of one session. Sizes can mislead;
+  always rely on grep'd content matches, not file size.
+- The UUID is stable forever — once pinned, the alias keeps working across
+  reboots, OS upgrades, even years (assuming the .jsonl isn't deleted).
+- If user has multiple long-running parallel sessions (e.g., two different
+  projects, both started from HOME), each needs its own pin. Repeat the
+  workflow once per session.
+- Don't confuse session UUIDs across different conversations. If two Claude
+  instances both claim the same UUID, at least one is wrong — only grep on
+  actual unique content can verify.
+
+## Quick check
+
+After pinning, verify:
+
+```bash
+source ~/.zshrc && type <short-name>
+```
+
+Should show the function definition.


### PR DESCRIPTION
## Summary

Adds a new skill that helps users pin a specific Claude Code conversation by UUID and resume it with a one-word shell command (e.g. `headsup`, `aichain`).

## Why

`claude --continue` picks the *most recent* conversation in cwd, which is unreliable when:
- Multiple long-running parallel conversations live in the same project
- All your sessions are stored in the home-dir bucket (because you started Claude Code from `~`)
- You want to come back to "this exact conversation" days/weeks later, not "whatever's most recent"

`claude --resume <uuid>` is exact, but finding the right UUID is its own dance. This skill walks Claude through a grep-the-jsonl workflow, then auto-writes a `~/.zshrc` function so you never have to look up a UUID again.

## What's in this PR

- \`find-session/SKILL.md\` — the skill itself (markdown, no code)
- \`find-session/README.md\` — user-facing docs / how to invoke
- Updated repo \`README.md\` — adds find-session as the 3rd skill in the list

## Test plan

- [ ] Invoke from a Claude Code session: \"我找不到我的对话, 帮我找出来\"
- [ ] Skill triggers, asks for unique-content hint
- [ ] grep matches exactly one .jsonl
- [ ] \`~/.zshrc\` gets the function appended
- [ ] \`source ~/.zshrc && type <name>\` shows the function
- [ ] New terminal: \`<name>\` resumes the right conversation